### PR TITLE
Config file input

### DIFF
--- a/minidock/container_assemble.bzl
+++ b/minidock/container_assemble.bzl
@@ -1,4 +1,4 @@
-load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo", "ManifestResult", "AssembledData", "container_info_struct")
+load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo", "ManifestResult", "AssembledData", "ExternalContainerConfig", "container_info_struct")
 
 
 launcher_template = """
@@ -31,6 +31,7 @@ def __container_assemble_impl(ctx):
 
     composed = ctx.attr.composed[ContainerInfo]
     composed_transitive_deps = composed.dependencies
+    composed_external_config = ctx.attr.composed[ExternalContainerConfig]
 
     merger_config_output = ctx.actions.declare_file("%s_merger_config.json" % ctx.attr.name)
     merger_manifest_output = ctx.actions.declare_file("%s_merger_manifest.json" % ctx.attr.name)
@@ -46,6 +47,9 @@ def __container_assemble_impl(ctx):
     merger_args.add("--manifest-sha256-path").add(merger_manifest_sha256_output.path)
     merger_args.add("--upload-metadata-path").add(merger_upload_metadata_output.path)
     merger_args.add("--config-path").add(merger_config_output.path)
+
+    if composed_external_config:
+        merger_args.add("--external-config-path").add(composed_external_config.config)
 
     merger_input = depset([merger_config_file], transitive = [composed_transitive_deps])
     ctx.actions.run(

--- a/minidock/container_assemble.bzl
+++ b/minidock/container_assemble.bzl
@@ -48,10 +48,13 @@ def __container_assemble_impl(ctx):
     merger_args.add("--upload-metadata-path").add(merger_upload_metadata_output.path)
     merger_args.add("--config-path").add(merger_config_output.path)
 
-    if composed_external_config:
-        merger_args.add("--external-config-path").add(composed_external_config.config)
+    inputs = [merger_config_file]
+    for target in composed_external_config.config:
+        external_config_files = target.files.to_list()
+        inputs = inputs + external_config_files
+        merger_args.add("--external-config-path").add_all(external_config_files)
 
-    merger_input = depset([merger_config_file], transitive = [composed_transitive_deps])
+    merger_input = depset(inputs, transitive = [composed_transitive_deps])
     ctx.actions.run(
         inputs = merger_input,
         outputs = [merger_config_output, merger_manifest_output, merger_upload_metadata_output, merger_manifest_sha256_output],

--- a/minidock/container_assemble.bzl
+++ b/minidock/container_assemble.bzl
@@ -48,13 +48,13 @@ def __container_assemble_impl(ctx):
     merger_args.add("--upload-metadata-path").add(merger_upload_metadata_output.path)
     merger_args.add("--config-path").add(merger_config_output.path)
 
-    inputs = [merger_config_file]
+    transdepsets = [composed_transitive_deps]
     for target in composed_external_config.config:
-        external_config_files = target.files.to_list()
-        inputs = inputs + external_config_files
+        external_config_files = target.files
+        transdepsets.append(external_config_files)
         merger_args.add("--external-config-path").add_all(external_config_files)
 
-    merger_input = depset(inputs, transitive = [composed_transitive_deps])
+    merger_input = depset([merger_config_file], transitive = transdepsets)
     ctx.actions.run(
         inputs = merger_input,
         outputs = [merger_config_output, merger_manifest_output, merger_upload_metadata_output, merger_manifest_sha256_output],

--- a/minidock/container_compose.bzl
+++ b/minidock/container_compose.bzl
@@ -1,4 +1,4 @@
-load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo")
+load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo", "ExternalContainerConfig")
 
 
 def __copy_provider_with(current, parent):
@@ -41,6 +41,7 @@ def __container_compose_impl(
     base_info = ctx.attr.base[ContainerInfo] if ctx.attr.base != None else None
     return [
         __align_parents(base_info, layers),
+        ExternalContainerConfig(config = ctx.attr.external_config)
     ]
 
 container_compose = rule(
@@ -53,6 +54,10 @@ container_compose = rule(
         "layers": attr.label_list(
             providers = [ContainerInfo],
         ),
+        "external_config": attr.label(
+            doc = "External config file to be merged with this composition",
+            mandatory = False,
+        )
     },
     implementation = __container_compose_impl,
 )

--- a/minidock/container_compose.bzl
+++ b/minidock/container_compose.bzl
@@ -54,9 +54,10 @@ container_compose = rule(
         "layers": attr.label_list(
             providers = [ContainerInfo],
         ),
-        "external_config": attr.label(
+        "external_config": attr.label_list(
             doc = "External config file to be merged with this composition",
             mandatory = False,
+            allow_files = True
         )
     },
     implementation = __container_compose_impl,

--- a/minidock/container_config.bzl
+++ b/minidock/container_config.bzl
@@ -1,4 +1,4 @@
-load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo", "ExternalContainerConfig")
+load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo")
 
 def __expand_env(ctx, env):
     env_lst = None
@@ -94,14 +94,4 @@ container_config = rule(
         )
     },
     implementation = __container_config__impl,
-)
-
-def __external_config__impl(ctx):
-    return [ExternalContainerConfig(config = ctx.file.config)]
-
-external_container_config = rule(
-    attrs = {
-        "config": attr.label(allow_single_file=True)
-    },
-    implementation = __external_config__impl
 )

--- a/minidock/container_config.bzl
+++ b/minidock/container_config.bzl
@@ -1,4 +1,4 @@
-load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo")
+load("@com_github_bazeltools_rules_minidock//minidock:providers.bzl", "ContainerInfo", "ExternalContainerConfig")
 
 def __expand_env(ctx, env):
     env_lst = None
@@ -36,7 +36,7 @@ def __container_config__impl(ctx):
             Env = __expand_env(ctx, ctx.attr.env),
             User = user,
             WorkingDir = workdir,
-            Labels = ctx.attr.labels
+            Labels = ctx.attr.labels,
         ),
     )
 
@@ -89,9 +89,19 @@ container_config = rule(
             default = "rules_minidock_is_unset",
         ),
         "labels": attr.string_dict(
-            doc = """Config labels. Will merge with parent labels: does *not replace all labels in parent dict.""",
+            doc = """Config labels. Will take precedence over any labels in labels_file""",
             mandatory = False,
-            )
+        )
     },
     implementation = __container_config__impl,
+)
+
+def __external_config__impl(ctx):
+    return [ExternalContainerConfig(config = ctx.file.config)]
+
+external_container_config = rule(
+    attrs = {
+        "config": attr.label(allow_single_file=True)
+    },
+    implementation = __external_config__impl
 )

--- a/minidock/providers.bzl
+++ b/minidock/providers.bzl
@@ -30,6 +30,12 @@ ContainerInfo = provider(fields = [
     "config",
 ])
 
+ExternalContainerConfig = provider(fields = [
+    # A target to an external config file that we can merge with
+    # all other config layers
+    "config"
+])
+
 def container_info_struct(container_info):
     # Building a struct of both our rule-provided info and the parent info
     # to pass to the merger app

--- a/minidock/remote_tools/repositories.bzl
+++ b/minidock/remote_tools/repositories.bzl
@@ -9,63 +9,63 @@ def load_tools():
     if "rules_minidock__merge_app_linux_x86_64" not in excludes:
         load_tool(
             name = "rules_minidock__merge_app_linux_x86_64",
-            sha256 = "9ae88eb012f6ddcdeef87e1bf0d2d050fac78e9007c78b3433d0ec44f0f20c4a",
+            sha256 = "a2f11bb0e135271a1d41a8812a2532e0ea8868d40ac89d00ac4e58b953b11e52",
             packaged = False,
             binary_path = "merge-app-linux-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/merge-app-linux-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/merge-app-linux-x86_64"],
         )
 
     if "rules_minidock__merge_app_macos_x86_64" not in excludes:
         load_tool(
             name = "rules_minidock__merge_app_macos_x86_64",
-            sha256 = "2ebb3e2d31686399b61c188d3519ad7cb762fcbcb42f6037e65cfa10f1e55578",
+            sha256 = "1591fc03b647b6d399e26250dd30115463a44215a1e343a067b0c75f8404287b",
             packaged = False,
             binary_path = "merge-app-macos-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/merge-app-macos-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/merge-app-macos-x86_64"],
         )
 
     if "rules_minidock__merge_app_macos_aarch64" not in excludes:
         load_tool(
             name = "rules_minidock__merge_app_macos_aarch64",
-            sha256 = "cf4ac984193348aa927ef567e18987e9fdceca04097d9386364b2537f20aa0bc",
+            sha256 = "4f3aa6d5984b138cd7af5811c346d53351d3ca02e8364d9072378965efb6240e",
             packaged = False,
             binary_path = "merge-app-macos-aarch64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/merge-app-macos-aarch64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/merge-app-macos-aarch64"],
         )
 
     if "rules_minidock__pusher_app_linux_x86_64" not in excludes:
         load_tool(
             name = "rules_minidock__pusher_app_linux_x86_64",
-            sha256 = "5406a376c263cf135ab1a7b7821eee935cb7d8d9374ebf45beb6dee39bc4cb7c",
+            sha256 = "1c83cb1c84239cbaddf58bac1b43ae83546c8cf5ec51a3a9aae9e4e3bcd3b538",
             packaged = False,
             binary_path = "pusher-app-linux-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/pusher-app-linux-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/pusher-app-linux-x86_64"],
         )
 
     if "rules_minidock__pusher_app_macos_x86_64" not in excludes:
         load_tool(
             name = "rules_minidock__pusher_app_macos_x86_64",
-            sha256 = "f109170cf9b486b8abbc8c1d581973d1c65ae5eb47ccaef2732f2d87f78be4b2",
+            sha256 = "d83b047bcbb47238a02897350f4f3ee24020f30cf70b0db7c226922d36d00b18",
             packaged = False,
             binary_path = "pusher-app-macos-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/pusher-app-macos-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/pusher-app-macos-x86_64"],
         )
 
     if "rules_minidock__pusher_app_macos_aarch64" not in excludes:
         load_tool(
             name = "rules_minidock__pusher_app_macos_aarch64",
-            sha256 = "077b894ae88997010bc228cf0d6a86388ccb1772f3edfda9062c8071b1d0b6c4",
+            sha256 = "33298b9299acba15e90667b806305a52de6146614124c790ef7def9305ff5c5c",
             packaged = False,
             binary_path = "pusher-app-macos-aarch64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/pusher-app-macos-aarch64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/pusher-app-macos-aarch64"],
         )
     if "rules_minidock__puller_app" not in excludes:
         repo_rule_load_tool(
             name="rules_minidock__puller_app",
             platform_to_sha_pairs = {
-                "linux__x86_64": ["c9b1c867a481f40c3078fef4eacc27f11150cf383feb6b038a1f2bd832ab5f6a", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/puller-app-linux-x86_64"],
-                "macos__x86_64": ["09b6ae3d3b9375de67784d2fe127bdcaf4f4af10b3ee7258bc01f8d5cb462a55", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/puller-app-macos-x86_64"],
-                "macos__aarch64": ["d65f6d8c556bc5840aac7b2fb8152d2cc6a3ae28381cc3309cff671684bd63f4", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.56/puller-app-macos-aarch64"],
+                "linux__x86_64": ["a6d338d9df9b9c087421152387cc5be19431f6dcff5b4d476ab2aace762bb067", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/puller-app-linux-x86_64"],
+                "macos__x86_64": ["bd52783111fe6c22647d2b5dddb680e7f46d08338dc96867fcceee54864131cb", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/puller-app-macos-x86_64"],
+                "macos__aarch64": ["5cc25b21a749d5384b6c374b4f9a02ce26cee2ea8aa349f948e5d4ff645b47cd", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.61/puller-app-macos-aarch64"],
             }
         )
     # RUST_BINARIES_AUTO_GEN_REPLACE_SECTION_END

--- a/scripts/ci_test.py
+++ b/scripts/ci_test.py
@@ -21,7 +21,14 @@ user = data["config"]["User"]
 env = data["config"]["Env"]
 
 expected_cmd = ["/usr/bin/my_app"]
-expected_labels = {"label1": "foo", "label2": "bar"}
+expected_labels = {
+    "label1": "foo",
+    "label2": "bar",
+    "external-config-label-1": "extlabel1",
+    "external-config-label-2": "extlabel2",
+    "external-config-label-3": "extlabel3",
+    "external-config-label-4": "extlabel4"
+}
 expected_user = "nfbasic"
 
 assert(cmd == expected_cmd)
@@ -31,6 +38,7 @@ assert(user == expected_user)
 assert(len(env) > 2)
 assert("ENV1=FOO" in env)
 assert("ENV2=BAR" in env)
+assert("EXTERNALENV1=extenv1" in env)
 
 subprocess.run(["bazel", "clean", "--expunge"], check=True)
 subprocess.run(["bazel", "build", "..."], check=True)

--- a/tests/simple_flow/BUILD.bazel
+++ b/tests/simple_flow/BUILD.bazel
@@ -19,6 +19,24 @@ load(
     "@com_github_bazeltools_rules_minidock//minidock:container_config.bzl",
     "container_config",
 )
+load(
+    "@com_github_bazeltools_rules_minidock//minidock:container_config.bzl",
+    "external_container_config",
+)
+
+genrule(
+    name = "external_config_file",
+    outs = ["ConfigFile.json"],
+    cmd = """
+cat << EOF > $@
+{
+  "Env": {"EXTERNALENV1": "extenv1"}
+  "Labels": {"external_label_1": "extl1",
+             "external_label_2": "extl2",}
+}
+EOF""",
+    stamp = 1,
+)
 
 container_data(
     name = "file_a_data",
@@ -46,6 +64,11 @@ container_config(
            "ENV2": "BAR"}
 )
 
+external_container_config(
+    name = "external_config_labels_and_env",
+    config = ":external_config_file"
+)
+
 container_compose(
     name = "test_simple_imagen",
     base = "@bazel_320//:metadata",
@@ -53,8 +76,9 @@ container_compose(
         ":file_a_data",
         ":file_b_data",
         ":user_and_app",
-        ":labels_and_env"
+        ":labels_and_env",
     ],
+    external_config = ":external_config_labels_and_env"
 )
 
 container_assemble(

--- a/tests/simple_flow/BUILD.bazel
+++ b/tests/simple_flow/BUILD.bazel
@@ -19,11 +19,6 @@ load(
     "@com_github_bazeltools_rules_minidock//minidock:container_config.bzl",
     "container_config",
 )
-load(
-    "@com_github_bazeltools_rules_minidock//minidock:container_config.bzl",
-    "external_container_config",
-)
-
 genrule(
     name = "external_config_file",
     outs = ["ConfigFile.json"],
@@ -37,6 +32,21 @@ cat << EOF > $@
     "label1": "this-will-get-overwritten-by-the-config-below",
     "external-config-label-1": "extlabel1",
     "external-config-label-2": "extlabel2"
+  }
+}
+EOF""",
+    stamp = 1,
+)
+
+genrule(
+    name = "external_config_file_2",
+    outs = ["ConfigFile2.json"],
+    cmd = """
+cat << EOF > $@
+{
+  "Labels": {
+    "external-config-label-3": "extlabel3",
+    "external-config-label-4": "extlabel4"
   }
 }
 EOF""",
@@ -69,11 +79,6 @@ container_config(
            "ENV2": "BAR"}
 )
 
-external_container_config(
-    name = "external_config_labels_and_env",
-    config = ":external_config_file"
-)
-
 container_compose(
     name = "test_simple_imagen",
     base = "@bazel_320//:metadata",
@@ -83,7 +88,7 @@ container_compose(
         ":user_and_app",
         ":labels_and_env",
     ],
-    external_config = ":external_config_labels_and_env"
+    external_config = [":external_config_file", ":external_config_file_2"]
 )
 
 container_assemble(

--- a/tests/simple_flow/BUILD.bazel
+++ b/tests/simple_flow/BUILD.bazel
@@ -30,9 +30,14 @@ genrule(
     cmd = """
 cat << EOF > $@
 {
-  "Env": {"EXTERNALENV1": "extenv1"}
-  "Labels": {"external_label_1": "extl1",
-             "external_label_2": "extl2",}
+  "Env": [
+    "EXTERNALENV1=extenv1"
+  ],
+  "Labels": {
+    "label1": "this-will-get-overwritten-by-the-config-below",
+    "external-config-label-1": "extlabel1",
+    "external-config-label-2": "extlabel2"
+  }
 }
 EOF""",
     stamp = 1,


### PR DESCRIPTION
We'd like to do be able to capture things from the environment/at runtime and have them merged in to the metadata of our docker container. One way we can do this is what you see in the BUILD.bazel file change below: we could have our `external_config_file` grab the git commit, git branch, etc and then have that merged in (I will probably update this PR to do just that, but for now its a static file). 

We will then pass that to the merger app, which will merge it alongside the various config that we layer into the composition. 

I was quite torn on exactly where to specify this, but container_compose felt like the right place for now. 

This will be WIP until I can merge the accompanying PR in rules_minidock_tools, which I will link in a moment. 