### PR TITLE
Update to rules_minidock_tools v0.0.71 binaries

### DIFF
--- a/minidock/remote_tools/repositories.bzl
+++ b/minidock/remote_tools/repositories.bzl
@@ -12,7 +12,7 @@ def load_tools():
             sha256 = "662d6ee62432320d1d9b2d387d2c28ae38d7372f33cf9a000c89a59c80e402f4",
             packaged = False,
             binary_path = "merge-app-linux-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/merge-app-linux-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/merge-app-linux-x86_64"],
         )
 
     if "rules_minidock__merge_app_macos_x86_64" not in excludes:
@@ -21,7 +21,7 @@ def load_tools():
             sha256 = "7e114248993811d867ebbe87afa24fe2bca83b955220e48c937db0d5440dfe99",
             packaged = False,
             binary_path = "merge-app-macos-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/merge-app-macos-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/merge-app-macos-x86_64"],
         )
 
     if "rules_minidock__merge_app_macos_aarch64" not in excludes:
@@ -30,42 +30,42 @@ def load_tools():
             sha256 = "80f03a97a4ac072e32c06df73787920769210678ad91cd6edbd4bd206a6fa3f9",
             packaged = False,
             binary_path = "merge-app-macos-aarch64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/merge-app-macos-aarch64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/merge-app-macos-aarch64"],
         )
 
     if "rules_minidock__pusher_app_linux_x86_64" not in excludes:
         load_tool(
             name = "rules_minidock__pusher_app_linux_x86_64",
-            sha256 = "c5f65bdf01b3395293208f41eddbf41c5af8698a3cc16213c0005c90c93e21e5",
+            sha256 = "7f4cb2c2e0fcc1fe7711096b4a30e96075651502a3af638a0cfebe29913d802e",
             packaged = False,
             binary_path = "pusher-app-linux-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/pusher-app-linux-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/pusher-app-linux-x86_64"],
         )
 
     if "rules_minidock__pusher_app_macos_x86_64" not in excludes:
         load_tool(
             name = "rules_minidock__pusher_app_macos_x86_64",
-            sha256 = "d3159b234c91ccd2108a2e1768db4f29f461698450637636f02318bae51dfda7",
+            sha256 = "219cade49181f220e7c91f0c04f4c1a1c3a4fc54384c7cd45ac46d44b1d74326",
             packaged = False,
             binary_path = "pusher-app-macos-x86_64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/pusher-app-macos-x86_64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/pusher-app-macos-x86_64"],
         )
 
     if "rules_minidock__pusher_app_macos_aarch64" not in excludes:
         load_tool(
             name = "rules_minidock__pusher_app_macos_aarch64",
-            sha256 = "9e9f617c6484318199ea8e3dad77e488371901565c7d658f438b8a2d7563d7ee",
+            sha256 = "9efad50ba74e8c1b9b4c1c18bd6504811037ae1ad33098eb750990ad6bcd4640",
             packaged = False,
             binary_path = "pusher-app-macos-aarch64",
-            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/pusher-app-macos-aarch64"],
+            urls = ["https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/pusher-app-macos-aarch64"],
         )
     if "rules_minidock__puller_app" not in excludes:
         repo_rule_load_tool(
             name="rules_minidock__puller_app",
             platform_to_sha_pairs = {
-                "linux__x86_64": ["53a164532a9108c08adf9a9a751c748ad6b8c7b9b33c32a97922ce6ef9bc6071", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/puller-app-linux-x86_64"],
-                "macos__x86_64": ["fc759f7402963f2917f2a6e00c8d4baa445b8977f99d1c16476ae197e00df8fb", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/puller-app-macos-x86_64"],
-                "macos__aarch64": ["7e9ad24b436f387d3289b9157c3a3193d73a2624f92081291f38cbc287c00239", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.70/puller-app-macos-aarch64"],
+                "linux__x86_64": ["edfe94378bfb815e7ce4a18f5048dddca63fe763f5c824f5081999174f2e4334", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/puller-app-linux-x86_64"],
+                "macos__x86_64": ["c0d0e238f986536e2c3f37096e0824429e1fb78bcf8319916c6e149ac5adfd55", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/puller-app-macos-x86_64"],
+                "macos__aarch64": ["968f41423689216d1dfb985502eabb0bb5b48001faad34b571ce9217ab3a013f", "https://github.com/bazeltools/rules_minidock_tools/releases/download/v0.0.71/puller-app-macos-aarch64"],
             }
         )
     # RUST_BINARIES_AUTO_GEN_REPLACE_SECTION_END


### PR DESCRIPTION
This fixes a bug with persisting auth info across redirects.