### PR TITLE
Replace struct.to_json with json_encode

### DIFF
--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -94,7 +94,7 @@ def __container_data_impl(
         tars = [f.path for f in ctx.files.tars],
     )
     manifest_file = ctx.actions.declare_file(ctx.attr.name + "-layer.manifest")
-    ctx.actions.write(manifest_file, manifest.to_json())
+    ctx.actions.write(manifest_file, json.encode(manifest))
     args.add(manifest_file, format = "--manifest=%s")
     args.add(ctx.attr.gzip_compression_level, format = "--gzip_compression_level=%s")
 


### PR DESCRIPTION
This API is deprecated per https://bazel.build/versions/7.2.0/rules/lib/builtins/struct#to_json and causes build errors since at least Bazel 8.0.0.