### PR TITLE
Pass mtime to build_tar.py

### DIFF
--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -97,7 +97,7 @@ def __container_data_impl(
     ctx.actions.write(manifest_file, json.encode(manifest))
     args.add(manifest_file, format = "--manifest=%s")
     args.add(ctx.attr.gzip_compression_level, format = "--gzip_compression_level=%s")
-    args.add(ctx.attr.mtime, format = "--default_mtime=%s")
+    args.add(ctx.attr.mtime, format = "--mtime=%s")
 
     ctx.actions.run(
         executable = ctx.executable._build_tar,

--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -163,7 +163,7 @@ container_data = rule(
             doc = "Set the mode of files added by the `files` attribute.",
         ),
         "mtime": attr.int(
-            default = 0, # January 1, 1970, 00:00:00 UTC
+            default = 1262304000, # January 1, 2010, 00:00:00 UTC
             doc = "The mtime value to use for files when making .tar.gz outputs."
         ),
         "symlinks": attr.string_dict(

--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -162,7 +162,7 @@ container_data = rule(
             default = "0o555",  # 0o555 == a+rx
             doc = "Set the mode of files added by the `files` attribute.",
         ),
-        "mtime": attr.string(
+        "mtime": attr.int(
             default = 0, # January 1, 1970, 00:00:00 UTC
             doc = "The mtime to use when making .tar.gz outputs, use portable for reproducible builds"
         ),

--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -97,6 +97,7 @@ def __container_data_impl(
     ctx.actions.write(manifest_file, json.encode(manifest))
     args.add(manifest_file, format = "--manifest=%s")
     args.add(ctx.attr.gzip_compression_level, format = "--gzip_compression_level=%s")
+    args.add(ctx.attr.mtime, format = "--default_mtime=%s")
 
     ctx.actions.run(
         executable = ctx.executable._build_tar,
@@ -160,6 +161,10 @@ container_data = rule(
         "mode": attr.string(
             default = "0o555",  # 0o555 == a+rx
             doc = "Set the mode of files added by the `files` attribute.",
+        ),
+        "mtime": attr.string(
+            default = 0, # January 1, 1970, 00:00:00 UTC
+            doc = "The mtime to use when making .tar.gz outputs, use portable for reproducible builds"
         ),
         "symlinks": attr.string_dict(
             doc = """Symlinks to create in the Docker image.

--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -164,7 +164,7 @@ container_data = rule(
         ),
         "mtime": attr.int(
             default = 0, # January 1, 1970, 00:00:00 UTC
-            doc = "The mtime to use when making .tar.gz outputs, use portable for reproducible builds"
+            doc = "The mtime value to use for files when making .tar.gz outputs."
         ),
         "symlinks": attr.string_dict(
             doc = """Symlinks to create in the Docker image.


### PR DESCRIPTION
### Problem/Solution

Some tooling will bulk when it sees a mtime of 0, one such tooling is python `ZipFile`. Update `container_data` rule to accept the a `mtime` attribute and pass it to `bazel_tar.py --default_mtime=`  