### PR TITLE
Deprecate cfg host

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Disable deprecated starlark host transitions
+common --incompatible_disable_starlark_host_transitions

--- a/minidock/container_assemble.bzl
+++ b/minidock/container_assemble.bzl
@@ -84,7 +84,7 @@ container_assemble = rule(
         ),
         "merger": attr.label(
             default = "@com_github_bazeltools_rules_minidock//minidock/remote_tools:merge_app",
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },

--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -141,7 +141,7 @@ container_data = rule(
     attrs = {
         "_build_tar": attr.label(
             default = Label("//minidock/container_data_tools:build_tar"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "data_path": attr.string(

--- a/minidock/container_push.bzl
+++ b/minidock/container_push.bzl
@@ -144,12 +144,12 @@ container_push = rule(
         ),
         "pusher": attr.label(
             default = "@com_github_bazeltools_rules_minidock//minidock/remote_tools:pusher_app",
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             allow_files = True,
         ),
         "authentication_helper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             allow_files = True,
             mandatory = False

--- a/minidock/external_container_repo.bzl
+++ b/minidock/external_container_repo.bzl
@@ -60,7 +60,7 @@ external_container_repo = repository_rule(
             doc = "Digest of the container image.",
         ),
         "puller": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = "@rules_minidock__puller_app//:exe",
             doc = "Override generated based on settings option to fetch metadata",
         ),
@@ -77,7 +77,7 @@ external_container_repo = repository_rule(
             doc = "Architecture.",
         ),
         "authentication_helper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             allow_files = True,
             mandatory = False


### PR DESCRIPTION
## Problem/ / Solution

`cfg = "host"` has been deprecated and mostly all transitioned to [exec](https://docs.bazel.build/versions/4.1.0/skylark/rules.html#configurations).