### PR TITLE
Use bazel mod dep zstd

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 # Required dependencies
 bazel_dep(name = "platforms", version = "0.0.11")
-
+bazel_dep(name = "zstd", version = "1.5.7")
 bazel_dep(name = "rules_multitool", version = "1.11.1")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -141,7 +141,9 @@
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
-    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
+    "https://bcr.bazel.build/modules/zstd/1.5.7/MODULE.bazel": "f5780cdbd6f4c5bb985a20f839844316fe48fb5e463056f372dbc37cfabdf450",
+    "https://bcr.bazel.build/modules/zstd/1.5.7/source.json": "f72c48184b6528ffc908a5a2bcbf3070c6684f3db03da2182c8ca999ae5f5cfd"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {

--- a/minidock/container_data.bzl
+++ b/minidock/container_data.bzl
@@ -115,11 +115,12 @@ def __container_data_impl(
     args.add(ctx.attr.zstd_compression_level, format = "--zstd_compression_level=%s")
     args.add(compression, format = "--compression=%s")
     args.add(ctx.attr.mtime, format = "--mtime=%s")
+    args.add(ctx.executable._zstd_tool.path, format = "--zstd_path=%s")
 
     ctx.actions.run(
         executable = ctx.executable._build_tar,
         arguments = [args],
-        inputs = ctx.files.tars + [manifest_file] + files,
+        inputs = ctx.files.tars + [manifest_file] + files + [ctx.executable._zstd_tool],
         outputs = [layer],
         use_default_shell_env = True,
         mnemonic = "ContainerData",
@@ -143,6 +144,12 @@ container_data = rule(
             default = Label("//minidock/container_data_tools:build_tar"),
             cfg = "exec",
             executable = True,
+        ),
+        "_zstd_tool": attr.label(
+            default = Label("@zstd//:zstd_cli"),
+            cfg = "exec",
+            executable = True,
+            allow_single_file = True,
         ),
         "data_path": attr.string(
             doc = """Root path of the files.

--- a/minidock/container_data_tools/BUILD
+++ b/minidock/container_data_tools/BUILD
@@ -1,5 +1,6 @@
 py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
+    data = ["@zstd//:zstd_cli"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Problem/Solution

Use https://registry.bazel.build/modules/zstd instead of assuming zstd is installed. 